### PR TITLE
Fix migration name in generator

### DIFF
--- a/lib/generators/active_record/sail_generator.rb
+++ b/lib/generators/active_record/sail_generator.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       source_root File.expand_path('../templates', __FILE__)
 
       def copy_sail_migration
-        migration_template 'settings_migration.rb', "db/migrate/#{target_name}.rb", migration_version: migration_version
+        migration_template 'settings_migration.rb', "db/migrate/#{target_name}.rb", migration_version: migration_version, migration_name: migration_name
       end
 
       def migration_version
@@ -19,6 +19,10 @@ module ActiveRecord
 
       def target_name
         name || 'create_sail_settings'
+      end
+
+      def migration_name
+        target_name.camelize
       end
     end
   end

--- a/lib/generators/active_record/templates/settings_migration.rb
+++ b/lib/generators/active_record/templates/settings_migration.rb
@@ -1,4 +1,4 @@
-class CreateSailSettings < ActiveRecord::Migration<%= migration_version %>
+class <%= migration_name %> < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :sail_settings do |t|
       t.string :name, null: false


### PR DESCRIPTION
Refers to #23.

@rohandaxini let me know your thoughts. This fixes the naming issue in the migrations.