### PR TITLE
Fix asset loading for Rails 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     sail (1.4.2)
       fugit
+      jquery-rails
       rails
       sass-rails
 
@@ -88,6 +89,10 @@ GEM
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
+    jquery-rails (4.3.3)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)

--- a/app/assets/javascripts/sail/application.js.erb
+++ b/app/assets/javascripts/sail/application.js.erb
@@ -10,5 +10,5 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require rails-ujs
+<% Rails::VERSION::MAJOR >= 5 ? require_asset("rails-ujs") : require_asset("jquery") && require_asset("jquery_ujs") %>
 //= require_tree .

--- a/sail.gemspec
+++ b/sail.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'fugit'
+  s.add_dependency 'jquery-rails'
   s.add_dependency 'rails'
   s.add_dependency 'sass-rails'
 


### PR DESCRIPTION
Fixes #35.

@rohandaxini I created a brand new Rails 4 app and think I figured out what was wrong. In Rails 4, jquery was needed for proper CSRF token functionality. That was replaced in Rails 5 by rails-ujs and jquery was no longer a dependency.

This PR conditionally requires the needed assets based on the Rails version. It should fix the asset issues.