### PR TITLE
Ensure that the Sail controller is inheriting from proper class

### DIFF
--- a/app/controllers/sail/settings_controller.rb
+++ b/app/controllers/sail/settings_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_dependency "sail/application_controller"
 
 module Sail
   # SettingsController


### PR DESCRIPTION
Ensure that the Sail controller is inheriting from the engine ApplicationController. While trying to get this gem to work in a new Rails6.beta1 project, the Sails::Settings controller was inheriting from the main app's ApplicationController instead of the engines. This fixes it, as per the Rails Guide https://guides.rubyonrails.org/engines.html#app-directory.