### PR TITLE
Start expiring cache fragments for relevancy score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Expire cache fragments after 500 new usages of each setting
+  so that the relevancy score actually updates.
+  
+*[@vinistock]*  
+
 ## 3.0.1 ##
 
 * Initialize Rails application when running rake tasks (bug)

--- a/lib/sail/instrumenter.rb
+++ b/lib/sail/instrumenter.rb
@@ -7,6 +7,8 @@ module Sail
   # setting usage and provide insights to
   # dashboard users.
   class Instrumenter
+    USAGES_UNTIL_CACHE_EXPIRE = 500
+
     # initialize
     #
     # Declare basic hash containing setting
@@ -21,6 +23,7 @@ module Sail
     # times a setting has been called
     def increment_usage_of(setting_name)
       @statistics[setting_name] += 1
+      expire_cache_fragment(setting_name) if (@statistics[setting_name] % USAGES_UNTIL_CACHE_EXPIRE).zero?
     end
 
     # relative_usage_of
@@ -32,6 +35,12 @@ module Sail
       return 0.0 if @statistics.empty?
 
       (100.0 * @statistics[setting_name]) / @statistics.values.reduce(:+)
+    end
+
+    private
+
+    def expire_cache_fragment(setting_name)
+      ActionController::Base.new.expire_fragment(/name: "#{setting_name}"/)
     end
   end
 end

--- a/spec/lib/instrumenter_spec.rb
+++ b/spec/lib/instrumenter_spec.rb
@@ -19,6 +19,11 @@ describe Sail::Instrumenter, type: :lib do
       subject
       expect(instrumenter.instance_variable_get(:@statistics)).to eq("setting" => 1)
     end
+
+    it "deletes cache fragment after reaching increment limit" do
+      expect_any_instance_of(ActionController::Base).to receive(:expire_fragment).with(/name: "setting"/)
+      500.times { instrumenter.increment_usage_of("setting") }
+    end
   end
 
   describe "#relative_usage_of" do


### PR DESCRIPTION
In order to properly present the relevancy score
in the dashboard, the view cache fragments need
to expire after a certain number of usages. After
expiring, the view re-renders and properly displays
the relevancy score.