### PR TITLE
Fix dynamic types being incorrectly cached

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
 Metrics/ClassLength:
-  Max: 150
+  Max: 175
 Style/GuardClause:
   Enabled: false
 Style/StringLiterals:


### PR DESCRIPTION
Ab test, throttle and cron types are evaluated every time Sail.get
is called. Therefore, its response cannot be cached.