### PR TITLE
Create monitor mode

### DIFF
--- a/app/assets/javascripts/settings.js.erb
+++ b/app/assets/javascripts/settings.js.erb
@@ -61,13 +61,20 @@ function toggleModal(modal) {
 function handleGenericClick(event) {
     let target = event.target;
 
-    if (target === sortMenu || sortMenu.contains(target) || target === orderButton || orderButton.contains(target) ||
-        target === profilesMenu || profilesMenu.contains(target) || target === profilesButton ||
-        profilesButton.contains(target) || target === guide || guide.contains(target) || target === guideButton) {
+    if (orderButton !== null && (target === sortMenu || sortMenu.contains(target) || target === orderButton || orderButton.contains(target))) {
         return;
     }
 
-    sortMenu.style.display = "none";
+    if (profilesButton !== null && (target === profilesMenu || profilesMenu.contains(target) || target === profilesButton ||
+        profilesButton.contains(target))) {
+        return;
+    }
+
+    if (target === guide || guide.contains(target) || target === guideButton) {
+        return;
+    }
+
+    if (sortMenu !== null) sortMenu.style.display = "none";
     profilesMenu.style.display = "none";
     guide.style.display = "none";
     dashboardBody.style.filter = "none";
@@ -75,20 +82,23 @@ function handleGenericClick(event) {
 
 function closeAllModals(event) {
     if (event.key === "Escape") {
-        sortMenu.style.display = "none";
+        if (sortMenu !== null) sortMenu.style.display = "none";
         profilesMenu.style.display = "none";
         guide.style.display = "none";
         dashboardBody.style.filter = "none";
     }
 }
 
-if (autoSearchEnabled === "true") {
-    queryElement.addEventListener("keyup", afterTypingQuery);
-    queryElement.addEventListener("keydown", clearTimer);
+if (queryElement !== null) {
+    if (autoSearchEnabled === "true") {
+        queryElement.addEventListener("keyup", afterTypingQuery);
+        queryElement.addEventListener("keydown", clearTimer);
+    }
+
+    orderButton.addEventListener("click", toggleSortMenu);
+    profilesButton.addEventListener("click", function () { toggleModal(profilesMenu) });
 }
 
-orderButton.addEventListener("click", toggleSortMenu);
-profilesButton.addEventListener("click", function () { toggleModal(profilesMenu) });
 guideButton.addEventListener("click", function () { toggleModal(guide) });
 document.body.addEventListener("click", handleGenericClick);
 document.addEventListener("keydown", closeAllModals);

--- a/app/assets/stylesheets/sail/application.scss
+++ b/app/assets/stylesheets/sail/application.scss
@@ -43,11 +43,10 @@ html, body {
     }
   }
 
-  #btn-guide {
+  .nav-button {
     float: right;
     position: relative;
     bottom: 50px;
-    right: 110px;
     font-size: 20px;
     font-family: "Raleway", sans-serif;
     outline: none;
@@ -58,6 +57,16 @@ html, body {
     &:hover {
       cursor: pointer;
     }
+  }
+
+  #btn-guide {
+    right: 110px;
+  }
+
+  #btn-monitor-mode,
+  #btn-regular-mode {
+    right: 120px;
+    padding: 1px 7px 2px 7px;
   }
 }
 

--- a/app/assets/stylesheets/sail/settings.scss
+++ b/app/assets/stylesheets/sail/settings.scss
@@ -226,12 +226,20 @@
       @-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
       @keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }
     }
+
+    &.minimal {
+      min-height: 50px;
+      padding-top: 0;
+
+      label {
+        font-size: 22px;
+      }
+    }
   }
 
   #search-container {
     #search-form {
       text-align: center;
-      padding-top: 25px;
 
       #query {
         height: 50px;
@@ -270,7 +278,7 @@
     }
 
     #btn-order {
-      margin: 25px 0 0 15px;
+      margin: 0 0 0 15px;
       height: 58px;
     }
 
@@ -303,13 +311,13 @@
     }
 
     #main-app-link {
-      margin: 25px 0 0 8px;
+      margin: 0 0 0 8px;
       height: 53px;
     }
 
     #btn-profiles {
       height: 58px;
-      margin: 25px 0 0 8px;
+      margin: 0 0 0 8px;
     }
   }
 

--- a/app/models/sail/setting.rb
+++ b/app/models/sail/setting.rb
@@ -12,7 +12,6 @@ module Sail
     class UnexpectedCastType < StandardError; end
 
     FULL_RANGE = (0...100).freeze
-    SETTINGS_PER_PAGE = 8
     AVAILABLE_MODELS = Dir["#{Rails.root}/app/models/*.rb"]
                        .map { |dir| dir.split("/").last.camelize.gsub(".rb", "") }.freeze
 
@@ -33,10 +32,10 @@ module Sail
 
     after_initialize :instantiate_caster
 
-    scope :paginated, lambda { |page|
+    scope :paginated, lambda { |page, per_page|
       select(:name, :description, :group, :value, :cast_type, :updated_at)
-        .offset(page.to_i * SETTINGS_PER_PAGE)
-        .limit(SETTINGS_PER_PAGE)
+        .offset(page.to_i * per_page)
+        .limit(per_page)
     }
 
     scope :by_query, lambda { |query|

--- a/app/views/layouts/sail/application.html.erb
+++ b/app/views/layouts/sail/application.html.erb
@@ -18,11 +18,18 @@
       <h1 class="title"><%= I18n.t("sail.page_title") %></h1>
     <% end %>
 
-    <button id="btn-guide" type="button">
+    <button id="btn-guide" type="button" class="nav-button">
       <%= I18n.t("sail.guide") %>
     </button>
+
+    <% if params[:monitor_mode] == Sail::ConstantCollection::TRUE %>
+      <%= link_to(I18n.t("sail.regular_mode"), settings_path, method: :get, class: "nav-button", id: "btn-regular-mode") %>
+    <% else %>
+      <%= link_to(I18n.t("sail.monitor_mode"), settings_path(monitor_mode: "true"), method: :get, class: "nav-button", id: "btn-monitor-mode") %>
+    <% end %>
   </nav>
 
+  <div class="clearfix"></div>
   <%= yield %>
 </div>
 </body>

--- a/app/views/sail/settings/_setting_minimal.html.erb
+++ b/app/views/sail/settings/_setting_minimal.html.erb
@@ -1,0 +1,6 @@
+<% cache setting_minimal, expires_in: Sail.configuration.cache_life_span do %>
+  <div class="card minimal">
+    <h2><%= setting_minimal.display_name %></h2>
+    <label><%= setting_minimal.value %></label>
+  </div>
+<% end %>

--- a/app/views/sail/settings/index.html.erb
+++ b/app/views/sail/settings/index.html.erb
@@ -1,12 +1,19 @@
 <div id="settings-dashboard">
-  <% cache @settings do %>
+  <% cache [@settings, params[:monitor_mode]] do %>
     <span id="notice-success" class="notice success"><%= I18n.t("sail.updated") %></span>
     <span id="notice-alert" class="notice alert"><%= I18n.t("sail.failed") %></span>
-    <%= render(partial: "search") %>
+
+    <% unless params[:monitor_mode] == Sail::ConstantCollection::TRUE %>
+      <%= render(partial: "search") %>
+    <% end %>
 
     <div id="settings-container">
       <% if @number_of_pages > 0 %>
-        <%= render(partial: "setting", collection: @settings) %>
+        <% if params[:monitor_mode] == Sail::ConstantCollection::TRUE %>
+          <%= render(partial: "setting_minimal", collection: @settings) %>
+        <% else %>
+          <%= render(partial: "setting", collection: @settings) %>
+        <% end%>
       <% else %>
         <h1><%= I18n.t("sail.no_settings") %></h1>
       <% end %>
@@ -18,13 +25,13 @@
       <div class="clearfix"></div>
 
       <div class="page-links">
-        <%= link_to("", settings_path(page: [params[:page].to_i - 1, 0].max), method: :get, id: "angle-left-link", title: I18n.t("sail.previous_page")) %>
+        <%= link_to("", settings_path(page: [params[:page].to_i - 1, 0].max, monitor_mode: params[:monitor_mode]), method: :get, id: "angle-left-link", title: I18n.t("sail.previous_page")) %>
 
         <% (0...@number_of_pages).each do |page| %>
-          <%= link_to(page + 1, settings_path(page: page), method: :get, class: params[:page].to_i == page || params[:page].blank? && page.zero? ? "active" : "") %>
+          <%= link_to(page + 1, settings_path(page: page, monitor_mode: params[:monitor_mode]), method: :get, class: params[:page].to_i == page || params[:page].blank? && page.zero? ? "active" : "") %>
         <% end %>
 
-        <%= link_to("", settings_path(page: [params[:page].to_i + 1, @number_of_pages - 1].min), method: :get, id: "angle-right-link", title: I18n.t("sail.next_page")) %>
+        <%= link_to("", settings_path(page: [params[:page].to_i + 1, @number_of_pages - 1].min, monitor_mode: params[:monitor_mode]), method: :get, id: "angle-right-link", title: I18n.t("sail.next_page")) %>
       </div>
     </div>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,4 +40,5 @@ en:
     available_groups_and_types: Available groups and types
     groups_are: "The groups currently used are:"
     types_are: "The cast types currently used are:"
-
+    regular_mode: Regular mode
+    monitor_mode: Monitor mode

--- a/lib/sail/constant_collection.rb
+++ b/lib/sail/constant_collection.rb
@@ -17,5 +17,7 @@ module Sail
     STALE = "stale"
     RECENT = "recent"
     FIELDS_FOR_SORT = %w[name updated_at cast_type group].freeze
+    SETTINGS_PER_PAGE = 8
+    MINIMAL_SETTINGS_PER_PAGE = 24
   end
 end

--- a/spec/controllers/sail/settings_controller_spec.rb
+++ b/spec/controllers/sail/settings_controller_spec.rb
@@ -25,7 +25,7 @@ describe Sail::SettingsController, type: :controller do
     end
 
     it "queries settings with pagination" do
-      expect(Sail::Setting).to receive(:paginated).with("1")
+      expect(Sail::Setting).to receive(:paginated).with("1", 8)
       subject
       expect(response).to have_http_status(:ok)
     end
@@ -56,6 +56,16 @@ describe Sail::SettingsController, type: :controller do
       it "invokes ordered_by properly" do
         subject
         expect(controller.instance_variable_get(:@settings).last.name).to eq(setting.name)
+      end
+    end
+
+    context "when passing monitor mode" do
+      let(:params) { { page: "1", monitor_mode: "true" } }
+
+      it "queries settings with pagination" do
+        expect(Sail::Setting).to receive(:paginated).with("1", 24)
+        subject
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/features/monitor_mode_feature_spec.rb
+++ b/spec/features/monitor_mode_feature_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+feature "monitor mode", js: true, type: :feature do
+  let!(:setting) do
+    Sail::Setting.create!(name: "setting", cast_type: :string,
+                          value: :something,
+                          description: "Setting that does something",
+                          group: "feature_flags")
+  end
+
+  before do
+    visit "/sail"
+  end
+
+  it "displays setting with minimalistic card" do
+    expect_setting(setting)
+
+    click_link("Monitor mode")
+
+    within(".card") do
+      expect(page).to have_text(setting.name.titleize)
+      expect(page).to have_text(setting.value)
+      expect(page).to have_no_text(setting.description.capitalize)
+      expect(page).to have_no_text(setting.cast_type)
+      expect(page).to have_no_text(setting.group)
+      expect(page).to have_no_field("value")
+    end
+
+    click_link("Regular mode")
+
+    expect_setting(setting)
+  end
+
+  it "allows viewing guide" do
+    click_link("Monitor mode")
+    click_button("Guide")
+
+    expect(page).to have_content("Reference Guide")
+    find("body").native.send_keys(:escape)
+    expect(page).to have_no_css("#guide-modal", visible: true)
+  end
+
+  context "when there is more than one page" do
+    before do
+      24.times do |index|
+        Sail::Setting.create!(name: "setting_#{index}", cast_type: :string,
+                              value: :something,
+                              description: "Setting that does something",
+                              group: "feature_flags")
+      end
+    end
+
+    it "allows navigating through pages" do
+      click_link("Monitor mode")
+      expect(all(".card").count).to eq(24)
+      click_link("2")
+      expect(all(".card").count).to eq(1)
+    end
+  end
+end

--- a/spec/models/sail/setting_spec.rb
+++ b/spec/models/sail/setting_spec.rb
@@ -117,8 +117,8 @@ describe Sail::Setting, type: :model do
       let!(:settings) { (0...40).map { |i| described_class.create(name: "setting_#{i}", cast_type: :integer, value: "0") } }
 
       it "paginates results" do
-        expect(described_class.paginated(0).map(&:name)).to eq(settings[0...8].map(&:name))
-        expect(described_class.paginated(1).map(&:name)).to eq(settings[8...16].map(&:name))
+        expect(described_class.paginated(0, 8).map(&:name)).to eq(settings[0...8].map(&:name))
+        expect(described_class.paginated(1, 8).map(&:name)).to eq(settings[8...16].map(&:name))
       end
     end
 


### PR DESCRIPTION
* Add new parameter to API monitor_mode
* Use monitor_mode to decide how many settings per page and to pick
  which partial to render for settings
* Create minimalistic card for settings in monitor mode
* Add monitor and regular mode links to navbar
* Prevent javascript from breaking due to missing search elements
* Start passing the monitor_mode parameter in navigation links