### PR TITLE
Depend on Rails  task instead of manual Rails initialization

### DIFF
--- a/lib/tasks/sail_tasks.rake
+++ b/lib/tasks/sail_tasks.rake
@@ -2,14 +2,12 @@
 
 namespace :sail do
   desc "Loads default setting configurations from sail.yml"
-  task :load_defaults do
-    Rails.application.initialize!
+  task load_defaults: :environment do
     Sail::Setting.load_defaults(true)
   end
 
   desc "Creates sail.yml using the current state of the database"
-  task :create_config_file do
-    Rails.application.initialize!
+  task create_config_file: :environment do
     Sail::Setting.database_to_file
   end
 end


### PR DESCRIPTION
As stated in the [docs](https://edgeguides.rubyonrails.org/command_line.html#custom-rake-tasks), if a custom task needs to interact with application models/classes, the custom task needs to depend on the `:environment` task. Thus, removing the need to explicitly call `Rails.application.initialize!`