### PR TITLE
Avoid N+1 queries

### DIFF
--- a/lib/sail/engine.rb
+++ b/lib/sail/engine.rb
@@ -42,7 +42,7 @@ module Sail
 
       # rubocop:disable Naming/RescuedExceptionsVariableName
       begin
-        Sail::Setting.load_defaults unless Rails.env.test?
+        Sail::Setting.includes(:entries).load_defaults unless Rails.env.test?
       rescue *errors
         warn "Skipping setting creation because database doesn't exist"
       end

--- a/lib/tasks/sail_tasks.rake
+++ b/lib/tasks/sail_tasks.rake
@@ -3,7 +3,7 @@
 namespace :sail do
   desc "Loads default setting configurations from sail.yml"
   task load_defaults: :environment do
-    Sail::Setting.load_defaults(true)
+    Sail::Setting.includes(:entries).load_defaults(true)
   end
 
   desc "Creates sail.yml using the current state of the database"

--- a/spec/models/sail/setting_spec.rb
+++ b/spec/models/sail/setting_spec.rb
@@ -529,7 +529,7 @@ describe Sail::Setting, type: :model do
   end
 
   describe ".load_defaults" do
-    subject { described_class.load_defaults(override) }
+    subject { described_class.includes(:entries).load_defaults(override) }
     let(:file_contents) { { "setting" => { "value" => "string_value", "cast_type" => "string" } } }
 
     before do


### PR DESCRIPTION
Avoid N+1 queries when loading defaults from `entries` table