### PR TITLE
Return the cached setting if set

### DIFF
--- a/app/models/sail/setting.rb
+++ b/app/models/sail/setting.rb
@@ -59,7 +59,12 @@ module Sail
 
     def self.get(name)
       Sail.instrumenter.increment_usage_of(name)
+      cached_setting = Rails.cache.read("setting_get_#{name}")
+
+      return cached_setting unless cached_setting.nil?
+
       setting = Setting.for_value_by_name(name).first
+
       return if setting.nil?
 
       if setting.should_not_cache?


### PR DESCRIPTION
Don't make the database query if the cached value is present.