### PR TITLE
Fix migration class inheritance for generators

### DIFF
--- a/lib/generators/sail/install/install_generator.rb
+++ b/lib/generators/sail/install/install_generator.rb
@@ -34,7 +34,7 @@ module Sail
       end
 
       def migration_version
-        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]" if Rails.version.start_with?("5")
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]" if Rails.version >= "5.0.0"
       end
     end
   end

--- a/lib/generators/sail/update/update_generator.rb
+++ b/lib/generators/sail/update/update_generator.rb
@@ -46,7 +46,7 @@ module Sail
       end
 
       def migration_version
-        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]" if Rails.version.start_with?("5")
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]" if Rails.version >= "5.0.0"
       end
     end
   end


### PR DESCRIPTION
Closes #139.

Make the generator create migrations with the appropriate class for inheritance.