### PR TITLE
Enhance pagination for numerous pages

### DIFF
--- a/app/views/sail/settings/index.html.erb
+++ b/app/views/sail/settings/index.html.erb
@@ -23,11 +23,21 @@
 
       <div class="page-links">
         <%= link_to("", settings_path(page: [params[:page].to_i - 1, 0].max, monitor_mode: params[:monitor_mode], query: params[:query]), method: :get, id: "angle-left-link", title: I18n.t("sail.previous_page")) %>
+        <%= link_to(1, settings_path(page: 0, monitor_mode: params[:monitor_mode], query: params[:query]), method: :get, class: params[:page].to_i.zero? || params[:page].blank? ? "active" : "") %>
 
-        <% (0...@number_of_pages).each do |page| %>
+        <% if params[:page].to_i - Sail::ConstantCollection::MAX_PAGES > 1 %>
+          ●●●
+        <% end %>
+
+        <% ([params[:page].to_i - Sail::ConstantCollection::MAX_PAGES, 1].max...[@number_of_pages - 1, params[:page].to_i + Sail::ConstantCollection::MAX_PAGES].min).each do |page| %>
           <%= link_to(page + 1, settings_path(page: page, monitor_mode: params[:monitor_mode], query: params[:query]), method: :get, class: params[:page].to_i == page || params[:page].blank? && page.zero? ? "active" : "") %>
         <% end %>
 
+        <% if params[:page].to_i + Sail::ConstantCollection::MAX_PAGES < @number_of_pages - 1 %>
+          ●●●
+        <% end %>
+
+        <%= link_to(@number_of_pages, settings_path(page: @number_of_pages - 1, monitor_mode: params[:monitor_mode], query: params[:query]), method: :get, class: params[:page].to_i == @number_of_pages - 1 ? "active" : "") %>
         <%= link_to("", settings_path(page: [params[:page].to_i + 1, @number_of_pages - 1].min, monitor_mode: params[:monitor_mode], query: params[:query]), method: :get, id: "angle-right-link", title: I18n.t("sail.next_page")) %>
       </div>
     </div>

--- a/lib/sail/constant_collection.rb
+++ b/lib/sail/constant_collection.rb
@@ -20,5 +20,6 @@ module Sail
     SETTINGS_PER_PAGE = 8
     MINIMAL_SETTINGS_PER_PAGE = 24
     INPUT_DATE_FORMAT = "%Y-%m-%dT%H:%m:%S"
+    MAX_PAGES = 5
   end
 end

--- a/spec/features/viewing_settings_feature_spec.rb
+++ b/spec/features/viewing_settings_feature_spec.rb
@@ -99,4 +99,24 @@ feature "viewing settings", js: true, type: :feature do
       end
     end
   end
+
+  it "adjusts pagination if there are too many settings" do
+    50.times do |index|
+      Sail::Setting.create!(name: "new_setting_#{index}", cast_type: :string,
+                            value: :something,
+                            description: "Setting that does something",
+                            group: "feature_flags")
+    end
+
+    visit "/sail"
+
+    within("#pagination") do
+      expect(page).to have_content("1 2 3 4 5 ●●● 8")
+      click_link("8")
+    end
+
+    within("#pagination") do
+      expect(page).to have_content("1 ●●● 3 4 5 6 7 8")
+    end
+  end
 end


### PR DESCRIPTION
Closes #152. This PR will make the pagination "slide" the maximum number of pages and only display links for a limited amount. It should look like this:

`< 1 2 3 4 5 ... 10 >`

Then after going to a page in the middle:

`< 1 ... 3 4 5 6 7 ... 10 >`

Then after going to the end:

`< 1 ... 5 6 7 8 9 10 >`

cc @oleg-kiviljov 