### PR TITLE
Fix 'No settings found' position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.1 ##
+
+* Fix position of "No settings found" text *[@vinistock]*
+
 ## 3.5.0 ##
 
 ### UI refactors

--- a/app/assets/stylesheets/sail/settings.css
+++ b/app/assets/stylesheets/sail/settings.css
@@ -22,6 +22,10 @@
     padding: 0 15px 0 15px;
 }
 
+#settings-dashboard #settings-container.empty {
+    justify-content: center;
+}
+
 #settings-dashboard .card {
     flex: 0 1 auto;
     max-height: 220px;

--- a/app/helpers/sail/application_helper.rb
+++ b/app/helpers/sail/application_helper.rb
@@ -9,5 +9,9 @@ module Sail
     def formatted_date(setting)
       DateTime.parse(setting.value).utc.strftime(Sail::ConstantCollection::INPUT_DATE_FORMAT)
     end
+
+    def settings_container_class(number_of_pages)
+      number_of_pages.zero? ? "empty" : ""
+    end
   end
 end

--- a/app/views/sail/settings/index.html.erb
+++ b/app/views/sail/settings/index.html.erb
@@ -2,7 +2,7 @@
   <% cache @settings do %>
     <%= render(partial: "search") %>
 
-    <div id="settings-container">
+    <div id="settings-container" class="<%= settings_container_class(@number_of_pages) %>">
       <% if @number_of_pages > 0 %>
         <%= render(partial: "setting", collection: @settings) %>
       <% else %>

--- a/spec/helpers/sail/application_helper_spec.rb
+++ b/spec/helpers/sail/application_helper_spec.rb
@@ -19,4 +19,18 @@ describe Sail::ApplicationHelper, type: :helper do
       expect(subject).to eq("2019-01-01T10:01:00")
     end
   end
+
+  describe "#settings_container_class" do
+    subject { settings_container_class(pages) }
+
+    context "when there's a page or more" do
+      let(:pages) { 1 }
+      it { is_expected.to eq("") }
+    end
+
+    context "when there are no pages" do
+      let(:pages) { 0 }
+      it { is_expected.to eq("empty") }
+    end
+  end
 end


### PR DESCRIPTION
The text was not aligning properly due to the recent changes to use flex properties.