### PR TITLE
Cookie session store conflicts with AR session store in main app

### DIFF
--- a/lib/sail/engine.rb
+++ b/lib/sail/engine.rb
@@ -14,7 +14,6 @@ module Sail
 
     config.middleware.use ActionDispatch::Flash
     config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore
     config.middleware.use ActionDispatch::ContentSecurityPolicy::Middleware if defined?(ActionDispatch::ContentSecurityPolicy)
     config.middleware.use Rack::MethodOverride
     config.middleware.use Rails::Rack::Logger

--- a/lib/sail/engine.rb
+++ b/lib/sail/engine.rb
@@ -39,6 +39,8 @@ module Sail
       errors = [ActiveRecord::NoDatabaseError]
       errors << PG::ConnectionBad if defined?(PG)
 
+      config.middleware.use Rails.application.config.session_store || ActionDispatch::Session::CookieStore
+
       begin
         Sail::Setting.load_defaults unless Rails.env.test?
       rescue *errors


### PR DESCRIPTION
Simply removing the cookie session store allows Sail to be mounted in an app with ActiveRecord sessions.

With the cookie store specified, attempting to access the Sail path in such an app throws errors - see issue #326 

I assume this PR is not an acceptable solution, presumably the cookie store is there for a reason! :) But I thought it might make a useful starting point for working things out...