### PR TITLE
Fix 'Proc without block' error (issue #330)

### DIFF
--- a/lib/sail/engine.rb
+++ b/lib/sail/engine.rb
@@ -49,9 +49,9 @@ module Sail
 
     private
 
-    def to_prepare
+    def to_prepare(&block)
       klass = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
-      klass.to_prepare(&Proc.new)
+      klass.to_prepare(&block)
     end
   end
 end


### PR DESCRIPTION
Passing the block explicitly allows this code to run in Ruby 3.0.0

I know this syntax was also valid in Ruby 2.7.2, and I think it passed my tests in 2.6.6 and 2.5.8 as well, but not positive. No idea further back than that, sorry!