### PR TITLE
Avoid manually expiring cache fragments

### DIFF
--- a/app/models/sail/setting.rb
+++ b/app/models/sail/setting.rb
@@ -162,6 +162,13 @@ module Sail
       try(:caster).try(:to_value)
     end
 
+    # cache_index
+    #
+    # Used in _setting.html.erb for the cache_key
+    def cache_index
+      Sail.instrumenter[name][:usages] / Instrumenter::USAGES_UNTIL_CACHE_EXPIRE
+    end
+
     private
 
     def instantiate_caster

--- a/app/views/sail/settings/_setting.html.erb
+++ b/app/views/sail/settings/_setting.html.erb
@@ -1,4 +1,4 @@
-<% cache setting, expires_in: Sail.configuration.cache_life_span do %>
+<% cache [setting, setting.cache_index], expires_in: Sail.configuration.cache_life_span do %>
   <div class="card">
     <div class="front">
       <h3 class="title card-title"><%= setting.display_name %></h3>

--- a/spec/features/relevancy_score_feature_spec.rb
+++ b/spec/features/relevancy_score_feature_spec.rb
@@ -16,6 +16,8 @@ feature "relevancy score", js: true, type: :feature do
   end
 
   before do
+    ActionController::Base.new.expire_fragment(/name: "#{setting_1.name}"/)
+    ActionController::Base.new.expire_fragment(/name: "#{setting_2.name}"/)
     Sail.instrumenter.instance_variable_set(:@number_of_settings, Sail::Setting.count)
     Sail.instrumenter.instance_variable_set(:@statistics, { settings: {}, profiles: {} }.with_indifferent_access)
     visit "/sail"

--- a/spec/lib/instrumenter_spec.rb
+++ b/spec/lib/instrumenter_spec.rb
@@ -20,11 +20,6 @@ describe Sail::Instrumenter, type: :lib do
       expect(instrumenter.instance_variable_get(:@statistics)).to eq("settings" => { "setting" => { "usages" => 1, "failures" => 0 } },
                                                                      "profiles" => {})
     end
-
-    it "deletes cache fragment after reaching increment limit" do
-      expect_any_instance_of(ActionController::Base).to receive(:expire_fragment).with(/name: "setting"/)
-      500.times { instrumenter.increment_usage_of("setting") }
-    end
   end
 
   describe "#relative_usage_of" do

--- a/spec/models/sail/setting_spec.rb
+++ b/spec/models/sail/setting_spec.rb
@@ -685,4 +685,23 @@ describe Sail::Setting, type: :model do
 
     it { is_expected.to eq(true) }
   end
+
+  describe "#cache_index" do
+    let(:setting) { described_class.create!(name: :setting, cast_type: :string, value: "Some string") }
+
+    before do
+      Sail.instrumenter.instance_variable_set(:@number_of_settings, Sail::Setting.count)
+      Sail.instrumenter.instance_variable_set(:@statistics, { settings: {}, profiles: {} }.with_indifferent_access)
+    end
+
+    it "increments according to Instrumenter::USAGES_UNTIL_CACHE_EXPIRE" do
+      expect(setting.cache_index).to eq(0)
+
+      500.times { Sail.get(:setting) }
+      expect(setting.cache_index).to eq(1)
+
+      500.times { Sail.get(:setting) }
+      expect(setting.cache_index).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Closes #426

Instead of manually expiring the cache fragments every 500 usages, turn the usages into a cache index that can be used in the fragment's cache key, allowing Rails to handle everything on its own.